### PR TITLE
metadata: add file size and temp download link

### DIFF
--- a/megadown
+++ b/megadown
@@ -470,11 +470,6 @@ if [ $(echo -n "$link" | grep -E -o 'mega(\.co)?\.nz') ]; then
 		file_name="$output"
 	fi
 
-	if [ $metadata ]; then
-		echo "{\"file_name\" : \"${file_name}\", \"file_size\" : ${file_size}}"
-		exit 0
-	fi
-
 	check_file_exists "$file_name" "$file_size" "$(format_file_size "$file_size")"
 
 	if [ $(echo -n "$link" | grep -E -o 'mega(\.co)?\.nz/#!') ]; then
@@ -492,6 +487,12 @@ if [ $(echo -n "$link" | grep -E -o 'mega(\.co)?\.nz') ]; then
 	fi
 
 	dl_temp_url=$(echo "$mega_res_json" | jq -r .[0].g)
+	
+	if [ $metadata ]; then
+		echo "{\"file_name\" : \"${file_name}\", \"file_size\" : ${file_size}, \"url\" : \"${dl_temp_url}\"}"
+		exit 0
+	fi
+
 else
 
 	#MEGACRYPTER LINK


### PR DESCRIPTION
I've moved the metadata check below after getting the file size and temp download link, so '-m' can now print the whole file info.